### PR TITLE
49 ubicación de ordenamiento en backend

### DIFF
--- a/statClient/src/components/table.tsx
+++ b/statClient/src/components/table.tsx
@@ -34,40 +34,6 @@ interface IData {
 
 }
 
-function sortArray (dataToSort:any) {
-  if (dataToSort.length > 0) {
-    // setDataSorted(dataToSort);
-   dataToSort.sort(function(a: any,b:any) {
-        //Sort by less time
-        return a.total_response_time - b.total_response_time;
-    })
-   dataToSort.sort(function(a: any,b:any) {
-        //Sort by status of album (enden or not)
-        if (a.ended_album > b.ended_album) {
-            return -1;
-        }
-
-        if (a.ended_album < b.ended_album) {
-            return 1;
-        }
-        // //Sort by less error number
-        return a.error_number - b.error_number ;
-    })
-  }
-  return addRank(dataToSort)
-}
-//Método que añade posiciones
-function addRank(arrayData:any) {
-  let position = 1
-  for (let index = 0; index < arrayData.length; index++) {
-    const element = arrayData[index];
-    element.rank = position++;
-  }
-  // console.log(arrayData)
-  return arrayData
-}
-
-
 export default function BasicTable() {
 
   const [selectedDate, setSelectedDate] = useState(today);
@@ -83,7 +49,7 @@ export default function BasicTable() {
     axios
       .get("http://localhost:3004/user")//Url api server
       .then((res) => {
-        setData(sortArray(res.data.data));
+        setData(res.data.data);
 
       })
       .catch((error) => {

--- a/statClient/src/components/table.tsx
+++ b/statClient/src/components/table.tsx
@@ -178,7 +178,7 @@ export default function BasicTable() {
               <TableCell align="right">{row.ended_album? "Sí" : "No"}</TableCell>
               <TableCell align="right">{row.answered_question_number}</TableCell>
               <TableCell align="right">{row.error_number}</TableCell>
-              <TableCell align="right">{row.error_percentage*100}%</TableCell>
+              <TableCell align="right">{row.error_percentage}%</TableCell>
               <TableCell align="right">{row.total_response_time}</TableCell>
 
             </TableRow>

--- a/statServer/models/user_answer_model.ts
+++ b/statServer/models/user_answer_model.ts
@@ -3,18 +3,33 @@ import {db} from "../db";
 import { RowDataPacket } from "mysql2";
 
 
-/*
+// Método en reemplazo del hook useSort, por medio del cual se ejecutaban un
+// ordenamiento según instrucciones, sobre el erray en bruto extraído
+// de la BD.
+function sortArray(dataToSort: any) {
+	if (dataToSort.length > 0) {
+		// Organización por menor tiempo que se hace primero para hacer el descarte
+		dataToSort.sort(function (a: any, b: any) {
+			return a.total_response_time - b.total_response_time;
+		});
+		//Organización por porcentaje de errores, que son los errores de un usuario
+		//con respecto a las respuestas respondidas
+		dataToSort.sort(function (a: any, b: any) {
+			return a.error_percentage - b.error_percentage;
+		});
+		//Organización por terminación del album (album finalizado o no)
+		dataToSort.sort(function (a: any, b: any) {
+			if (a.ended_album > b.ended_album) {
+				return -1;
+			}
 
-    SELECT album_id, COUNT(*) AS errores
-FROM user_answer
-WHERE success is null or success = 0
-GROUP BY album_id
-UNION
-SELECT album_id, 0 AS errores
-FROM user_answer
-WHERE album_id NOT IN (SELECT album_id FROM user_answer WHERE success = 0)
-GROUP BY album_id;
-*/
+			if (a.ended_album < b.ended_album) {
+				return 1;
+			}
+		});
+	}
+	return dataToSort;
+}
 
 export const findAll = (callback: Function) => {
 const queryString = `
@@ -84,6 +99,6 @@ GROUP BY album_id
         }
           userAnswers.push(a_id);
       });
-      callback(null, userAnswers);
+      callback(null, sortArray(userAnswers));
     });
   }

--- a/statServer/models/user_answer_model.ts
+++ b/statServer/models/user_answer_model.ts
@@ -29,7 +29,7 @@ SELECT
     ABS((ROUND((ABS((SUM(CASE
                         WHEN user_answer.success = 0 THEN 1
                         ELSE 0
-                    END) - COUNT(user_answer.question_id)) / COUNT(user_answer.question_id)) * 100), 0) - 100))/100 AS porcentaje_error,
+                    END) - COUNT(user_answer.question_id)) / COUNT(user_answer.question_id)) * 100), 0) - 100)) AS porcentaje_error,
     SUM(latency) AS tiempo_total_de_respuesta,
     album.started_on as epocas
 FROM

--- a/statServer/models/user_answer_model.ts
+++ b/statServer/models/user_answer_model.ts
@@ -28,7 +28,17 @@ function sortArray(dataToSort: any) {
 			}
 		});
 	}
-	return dataToSort;
+	return addRank(dataToSort);
+}
+//Método que añade posiciones al array organizado
+function addRank(arrayData: any) {
+	let position = 1;
+	for (let index = 0; index < arrayData.length; index++) {
+		const element = arrayData[index];
+		element.rank = position++;
+	}
+	// console.log(arrayData)
+	return arrayData;
 }
 
 export const findAll = (callback: Function) => {


### PR DESCRIPTION
Recomiendo que este pull request se una a la rama principal después de revisar el de la rama 47 porque tiene cambios en partes del código donde se trabajó en aquel y puede que si se hace al revés haya problemas. 

Ahora el ordenamiento y el otorgar la posición están en el backend, con lo que el array final extraído por el front está ya adecuado para mostrarlo al usuario.

También revisé la sentencia SQL para extraer porcentajes y quité una instrucción que hacía falta para que se mostraran correctamente como números enteros.

